### PR TITLE
Relocate "original-" jar to project build directory instead of output directory

### DIFF
--- a/src/main/java/net/md_5/specialsource/mavenplugin/RemapMojo.java
+++ b/src/main/java/net/md_5/specialsource/mavenplugin/RemapMojo.java
@@ -253,7 +253,7 @@ public class RemapMojo extends AbstractMojo {
     {
         getLog().info( "Replacing " + oldFile + " with " + newFile );
 
-        File origFile = new File( outputDirectory, "original-" + oldFile.getName() );
+        File origFile = new File( project.getBuild().getDirectory(), "original-" + oldFile.getName() );
         if ( oldFile.exists() && !oldFile.renameTo( origFile ) )
         {
             //try a gc to see if an unclosed stream needs garbage collecting


### PR DESCRIPTION
A configuration
```
<finalName>Foo</finalName>
<outputDirectory>bar/</outputDirectory>```
Will produce a jar named Foo.jar and original-Foo.jar in the bar/ directory. This PR moves the original-Foo.jar to the appropriate build directory (e.g. target/).

I'm not very familiar with maven conventions, so if there is a better solution that involve project parameters I'd be happy to use that. I personally don't like the idea of filling a specified output directory with previous versions of jars, so this aims to remedy that.