### PR TITLE
Fix SpecialSource not working properly on Windows

### DIFF
--- a/src/main/java/net/md_5/specialsource/mavenplugin/RemapMojo.java
+++ b/src/main/java/net/md_5/specialsource/mavenplugin/RemapMojo.java
@@ -180,7 +180,7 @@ public class RemapMojo extends AbstractMojo {
                     mapping.addExcludedPackage(packageName);
                 }
             }
-            if (srgIn.contains(":")) {
+            if (srgIn.contains(":") && (srgIn.length() > 1 && srgIn.charAt(1) != ':')) {
                 srgIn = resolveArtifact(srgIn).getPath();
             }
             mapping.loadMappings(srgIn, reverse, numeric, inShadeRelocation, outShadeRelocation);


### PR DESCRIPTION
SpecialSource stopped working on Windows systems after version 1.2.2.
This PR should fix that, I haven't tested it yet.

It might not be the best, but there's such a low chance that someone has `a:b:c` as the Maven artifact dependency name that it should be alright to do this. The reason is that Windows systems use drive letters, such as `C:\` and `F:\` which doesn't work well with the previous code. This PR checks if there's a `:` on the 2nd char of the string, which is true for Windows systems; and if so, skips resolving an artifact that's actually a path.